### PR TITLE
ragl: Fix for matchup calculation with forfeit players.

### DIFF
--- a/raglweb/__init__.py
+++ b/raglweb/__init__.py
@@ -325,7 +325,7 @@ def player(profile_id):
     # Calculate the fraction of the group stage that's complete.
     group_stage_completion = min(1, max(0, (date.today() - cfg['START_TIME']) / (group_stage_end_time - cfg['START_TIME'])))
 
-    matchup_expected_done = int(len(matches) * group_stage_completion)
+    matchup_expected_done = int(matchup_count * group_stage_completion)
 
     if player_info['status'] == 'SF':
         status = '⛔ Season Forfeit'


### PR DESCRIPTION
I managed to get this to work locally by building the ladder and then building the ragl site again.  I think something gets cached if I just rerun `make ragldev`.