### PR TITLE
ragl: Add Minions final.

### DIFF
--- a/laddertools/ragl-s11.yml
+++ b/laddertools/ragl-s11.yml
@@ -55,3 +55,8 @@ Playoffs:
             - 13705
             - 7304
             - 11705
+    Minions Championship:
+        bestof: 5
+        players:
+            - 11855
+            - 15421


### PR DESCRIPTION
This will be a BO5 between Kaution and Gajcus and is scheduled for the 17th of December.