### PR TITLE
Added Docker support

### DIFF
--- a/.docker/Dockerfile_base
+++ b/.docker/Dockerfile_base
@@ -1,0 +1,23 @@
+FROM python:3.9-slim
+
+RUN useradd -m -s /bin/bash openra \
+    && apt-get update && apt-get install -y --no-install-recommends make \
+    && apt-get clean
+
+RUN mkdir /home/openra/oraladder
+
+WORKDIR /home/openra/oraladder
+
+ADD ./laddermaps ./laddermaps
+ADD ./laddertools ./laddertools
+ADD ./ladderweb ./ladderweb
+ADD ./misc ./misc
+ADD ./raglweb ./raglweb
+ADD ./Makefile ./
+ADD ./MANIFEST.in ./
+ADD ./setup.py ./
+ADD ./LICENSE ./
+
+RUN chown openra: -R /home/openra
+
+USER openra

--- a/.docker/Dockerfile_ladder
+++ b/.docker/Dockerfile_ladder
@@ -1,0 +1,7 @@
+FROM oraladder/base:latest
+
+RUN make initladderdev
+
+RUN . venv/bin/activate && pip install gunicorn
+
+CMD ["venv/bin/gunicorn", "-b", "0.0.0.0:8000", "ladderweb:app"]

--- a/.docker/Dockerfile_ragl
+++ b/.docker/Dockerfile_ragl
@@ -1,0 +1,7 @@
+FROM oraladder/base:latest
+
+RUN make initragldev
+
+RUN . venv/bin/activate && pip install gunicorn
+
+CMD ["venv/bin/gunicorn", "-b", "0.0.0.0:8000", "raglweb:app"]

--- a/.docker/README.md
+++ b/.docker/README.md
@@ -1,0 +1,55 @@
+## Docker
+
+The entire architecture can be set up in containerized environment using Docker images.
+The following instructions do not include the OpenRA game servers, only the web 
+servers.
+
+These instructions expect you to know the basics of Docker and the Docker CLI.
+
+### Build
+
+First, you have to build the Docker images. To streamline this process, a shell script 
+is packaged with this repository. Run the shell script from the repository root 
+directory:
+
+```sh
+chmod +x .docker/build.sh
+.docker/build.sh
+```
+
+The script builds three Docker images:
+
+1. `oraladder/base:latest`, that collects all project files and dependencies
+2. `oraladder/ragl:latest`, that initializes the RAGL web server
+3. `oraladder/ladder:latest`, that initializes the Ladder web server
+
+### Run
+
+Export the path to your replay directory into the environment variable 
+`REPLAY_DIRECTORY`. Then run the RAGL or Ladder web service with the following 
+commands:
+
+```sh
+docker run --rm --name ragl -dit -p 8000:8000 -v $REPLAY_DIRECTORY:/replays/:ro oraladder/ragl:latest
+```
+
+```sh
+docker run --rm --name ladder -dit -p 8001:8000 -v $REPLAY_DIRECTORY:/replays/:ro oraladder/ladder:latest
+```
+
+NB: These containers will be removed entirely when stopped due to the `--rm` flag.
+
+### Update database
+
+To update the database files, you can use `docker exec` as follows for the 
+`ladder` container:
+
+```sh
+docker exec -it ladder venv/bin/ora-ladder -d instance/db-ra-all.sqlite3 /replays
+```
+
+To update the RAGL container, run
+
+```sh
+docker exec -it ragl venv/bin/ora-ragl -d instance/db-ragl.sqlite3 /replays
+```

--- a/.docker/build.sh
+++ b/.docker/build.sh
@@ -1,0 +1,30 @@
+#!/bin/sh
+#
+# Build OpenRA Ladder Docker images
+#
+# NB: run from project root directory (not within ".docker" directory)
+
+#
+# 0. prepare Dockerfile
+#
+cp .docker/Dockerfile* .
+
+#
+# 1. Build base image
+#
+docker build -t oraladder/base:latest -f Dockerfile_base .
+
+#
+# 2. Build RAGL image
+#
+docker build -t oraladder/ragl:latest -f Dockerfile_ragl .
+
+#
+# 3. Build OpenRA ladder image
+#
+docker build -t oraladder/ladder:latest -f Dockerfile_ladder .
+
+#
+# Cleanup
+#
+rm Dockerfile*

--- a/README.md
+++ b/README.md
@@ -42,6 +42,10 @@ ora-ladder -d db-ra-2m.sqlite3 -p 2m ~/.config/openra/Replays/ra
 cp db-ra-all.sqlite3 db-ra-2m.sqlite3 instance/
 ```
 
+### Docker
+
+The web services can be run in Docker containers. Please refer to the 
+[Docker instructions](.docker/README.md) for more information.
 
 ## Architecture
 


### PR DESCRIPTION
Hey,
since I am running the RAGL S12 infrastructure entirely in Docker containers, I wanted to share the necessary Dockerfiles.

This commit contains the Dockerfiles to build _images_ both for Ladder and RAGL usage as well as some basic instructions on how to operate them.